### PR TITLE
Fix broken tests by using waitFor to allow async execution to resolve

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,59 +1,46 @@
-import {useState, useEffect} from 'react';
-import {Tasks} from './components/Tasks';
-import {Textbox} from './components/Textbox';
+import { useState, useEffect } from "react";
+import { Tasks } from "./components/Tasks";
+import { Textbox } from "./components/Textbox";
 
-function App() {
-  const[task, setTask] = useState([]);
+export default function App() {
+
   const [tasks, setTasks] = useState([]);
 
-  useEffect(()=>{
-    document.querySelector("input").value = null;
-  }, [tasks]);
-
-  useEffect(()=>{
-    const previousTasks = localStorage.getItem('serverTasks');
-    if(previousTasks){
-      setTasks(JSON.parse(previousTasks ))
+  useEffect(() => {
+    const previousTasks = localStorage.getItem("serverTasks");
+    if (previousTasks) {
+      setTasks(JSON.parse(previousTasks));
     }
   }, []);
 
-  useEffect(()=>{
-    localStorage.setItem('serverTasks', JSON.stringify(tasks))
+  useEffect(() => {
+    localStorage.setItem("serverTasks", JSON.stringify(tasks));
   }, [tasks]);
 
-  const writeTask = async()=>{
+  const writeTask = async (task) => {
     const response = await fetch("/tasks", {
       method: "POST",
-      headers: {"content-type": "application/json"},
-      body: JSON.stringify({task})
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ task }),
     });
-
-    const updatedTasks = await response.json();
-
-    setTasks(updatedTasks);
+    setTasks(await response.json());
   };
 
-  const finishTask = (finishedTask)=>{
-    fetch("/delete-task", {
+  const finishTask = async (finishedTask) => {
+    const response = await fetch("/delete-task", {
       method: "DELETE",
-      headers: {"content-type": "application/json"},
-      body: JSON.stringify({finishedTask})
-    })
-    .then(res => res.json())
-    .then(updatedTasks => {
-      console.log("CLIENT SIDE DELETE REQUEST");
-      setTasks(updatedTasks)})
-      .catch(e => console.log(e));
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ finishedTask }),
+    });
+    setTasks(await response.json());
   };
 
   // console.log("just testing if console log is being logged in npm test");
 
   return (
-    <div className = "to-do-list">
-      <Tasks tasks={tasks} finishTask ={finishTask}/>
-      <Textbox tasks = {tasks} setTask={setTask} writeTask={writeTask}/>
+    <div className="to-do-list">
+      <Tasks tasks={tasks} finishTask={finishTask} />
+      <Textbox disabled={tasks.length >= 5} writeTask={writeTask} />
     </div>
   );
 }
-
-export default App;

--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -1,9 +1,6 @@
-export function Task({task, finishTask}){
+export function Task({ task, finishTask }) {
   return (
-    <li onClick={(e)=> {
-      console.log("TASK HAS BEEN CLICKED");
-      finishTask(e.target.textContent);}
-    } className="task">
+    <li onClick={(e) => finishTask(e.target.textContent)} className="task">
       {task}
     </li>
   );

--- a/src/components/Textbox.js
+++ b/src/components/Textbox.js
@@ -1,21 +1,29 @@
-export function Textbox({tasks, setTask, writeTask}){
+import { useState } from "react";
+
+export function Textbox({ disabled, writeTask }) {
+  const [task, setTask] = useState("");
+
   return (
-    <>
-    {
-      tasks.length < 5 ?
-      <div className="textbox">
-        <input onChange={(e)=> setTask(e.target.value)} type="text"></input>
-        <button onClick={writeTask} type="button" name="button">Post</button>
-      </div>
-      :
-      <div className="textbox">
-        <input disabled type="text"></input>
-        <button disabled type="button" name="button">Post</button>
-      </div>
-    }
-    </>
+    <div className="textbox">
+      <input
+        disabled={disabled}
+        type="text"
+        value={task}
+        onChange={(e) => setTask(e.target.value)}
+      ></input>
+      <button
+        disabled={disabled}
+        onClick={() => {
+          writeTask(task);
+          setTask("");
+        }}
+        type="button"
+      >
+        Post
+      </button>
+    </div>
   );
-};
+}
 
 //if testing textbox in isolation, what you want to say about it, when you click
 //button, write task gets called, clicking button calls function, doesn't matter

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,40 +1,26 @@
-import {rest} from 'msw';
+import { rest } from "msw";
 //rest namespace groups essentials needed for mocking a rest api
-import { setupServer } from 'msw/node';
+import { setupServer } from "msw/node";
 
 let tasks = [];
 
-const server = setupServer(
+export const server = setupServer(
   rest.get("/tasks", (req, res, ctx) => {
-    console.log(`get request tasks is ${tasks}`);
-    return res(
-      ctx.status(200),
-      ctx.json(tasks)
-    )
+    return res(ctx.status(200), ctx.json(tasks));
   }),
 
   rest.post("/tasks", (req, res, ctx) => {
-    const task = req.body.task;
-    const updatedTasks = [...tasks, task];
-    tasks = updatedTasks;
-    console.log(`post request tasks is ${updatedTasks}`);
-
-    return res(
-      ctx.status(200),
-      ctx.json(tasks)
-    )
+    tasks = [...tasks, req.body.task];
+    return res(ctx.status(200), ctx.json(tasks));
   }),
 
-  rest.delete("/delete-task", (req, res, ctx)=> {
+  rest.delete("/delete-task", (req, res, ctx) => {
     const task = req.body.finishedTask;
-    const updatedTasks = tasks.filter(x => x !== task);
-    tasks = updatedTasks;
-    console.log(`delete request tasks is ${updatedTasks}`);
-    return res(
-      ctx.status(200),
-      ctx.json(tasks)
-    )
-  }),
+    tasks = tasks.filter((x) => x !== task);
+    return res(ctx.status(200), ctx.json(tasks));
+  })
 );
 
-export {server};
+export function clearTasks() {
+  tasks = [];
+}


### PR DESCRIPTION
The commit might be a bit noisy because I did some auto-formatting. You can hide whitespace changes (i.e. changes in formatting such as adding or removing spaces) in the _Files changed_ tab by choosing _Hide whitespace changes_ under the gear.

The key change here that gets the tests to work the way we want is to `await waitFor(...)` and `await waitForElementToBeRemoved(...)` (in the delete case). Effectively, what these calls do is execute their given callbacks over and over until the callback succeeds (or fails in the case of waiting for the element to be removed). Both functions will only keep trying up to a maximum amount of time (until a "time out"), and will fail if they have not resolved by then. We use `waitFor` to find an element that should be in the DOM once all the async logic of fetching and setting state and rendering settles; we use `waitForElementToBeRemoved` to handle the case of removing a task, where after all the async logic settles, the element (task we clicked) should no longer be in the DOM.

Both functions return a `Promise`, and so we `await` on them so that we know the `Promise` has resolved before moving on. When we care about the result (like when we find the task to delete), this is obvious. What might be less obvious is when we do that as the last line of the test. The reason for this is that we want to make sure everything resolves before moving on. If we don't `await`, we could end up executing another test before we've fully finished the current one. `await` makes sure that we block and wait for everything to resolve and for the test to conclusively pass or fail (i.e. we found or didn't find the element we were expecting) before moving on to the next test.

One other thing I added was a `clearTasks` function in the mock server module. I call this function before each test so that we're guaranteed to start with an empty task list for each test. If we don't do this, tests like "add 5 tasks, then check the submit button is disabled" will not behave deterministically: if another test that adds a task runs first, then technically, the field will be disabled after adding four (or maybe less) tasks and we end up with really weird results where tests pass but sporadically there are errors about missing `act` or unmounted components being changed, etc. The core idea here is isolation: what's happened in one test should not be allowed to leak in to another test.